### PR TITLE
fix the multiple scale_xx_break bug and relative width/height bug and compatible theme_classic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.Rproj.user
+.Rhistory
+inst/doc
+vignettes/*.html

--- a/R/grid-draw-utilities.R
+++ b/R/grid-draw-utilities.R
@@ -16,9 +16,11 @@ subplot_theme <- function(plot, axis, type){
 axis_theme <- function(plot, axis){
     axis_theme <- switch(axis, 
                         x = theme(axis.text.y=element_blank(),
-                                  axis.ticks.y=element_blank()),
+                                  axis.ticks.y=element_blank(),
+                                  axis.line.y=element_blank()),
                         y = theme(axis.text.x=element_blank(),
-                                  axis.ticks.x=element_blank())
+                                  axis.ticks.x=element_blank(),
+                                  axis.line.x=element_blank())
                   )
     return(axis_theme)
 }

--- a/R/grid-draw-utilities.R
+++ b/R/grid-draw-utilities.R
@@ -63,26 +63,28 @@ check_coord_flip <- function(plot, axis){
     return ("coord_cartesian")
 }
 
-compute_relative_range <- function(breaks, scales, rng, coord_fun, axis){
-    baserange <- abs(diff(breaks[[1]]))
-    relranges <- mapply(compute_relative_range_, 
-                     breaks_=breaks[-1], 
+compute_relative_range <- function(breaks, scales, rng){
+    if(rng$flagrev=="reverse"){
+        baserange <- abs(diff(rev(breaks)[[1]]))
+        otherbk <- breaks[-length(breaks)]
+    }else{ 
+        baserange <- abs(diff(breaks[[1]]))
+        otherbk <- breaks[-1]
+    }
+    relranges <- unlist(mapply(compute_relative_range_, 
+                     breaks_= otherbk, 
                      scales_=scales, 
                      MoreArgs=list(baserange_=baserange), 
                      #baserange_ = baserange,
-                     SIMPLIFY=FALSE)
-    relranges <- c(baserange, unname(unlist(relranges)))
-    if (coord_fun=="coord_flip" && axis=="x"){
-        relranges <- c(relranges[1], rev(relranges[-1]))
+                     SIMPLIFY=FALSE))
+    if (rng$flagrev == "reverse"){
+        return (c(relranges, baserange)) 
+    }else{
+        return (c(baserange, relranges))
     }
-    if (rng$flagrev=="reverse" && coord_fun!="coord_flip" && axis =="y"){
-        relranges <- c(relranges[1], rev(relranges[-1]))
-    }
-    return(relranges)
 }
 
 compute_relative_range_ <- function(breaks_, scales_, baserange_){
-    scales_ <- unlist(scales_)
     if (scales_=="fixed"){
         return(abs(diff(breaks_)))
     }

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -5,12 +5,15 @@
 ggplot_add.ggbreak_params <- function(object, plot, object_name) {
     if (inherits(plot, "ggbreak")){
         origin_axis_break <- attr(plot, 'axis_break')
-        if (origin_axis_break$axis != object$axis){
+        origin_axis <- ifelse(inherits(origin_axis_break, "ggbreak_params"), 
+                              origin_axis_break$axis, 
+                              origin_axis_break[[1]]$axis)
+        if (origin_axis != object$axis){
             rlang::abort("The truncation of different axis is not be supported simultaneously.
                          The ", origin_axis_break$axis," axis of original plot has been
                          truncated.")
         }else{
-            object <- list(origin_axis_break, object)
+            object <- list.add(origin_axis_break, object)
         }
     }
     attr(plot, 'axis_break') <- object

--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -16,12 +16,11 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
     axis <- axis_breaks$axis
     breaks <- axis_breaks$breaks
     scales <- axis_breaks$scales
-    rng <- ggrange2(x, axis)
-    breaks <- combine_range(breaks, rng)
+    rng <- ggrange2(plot=x, var=axis)
+    res <- combine_range(breaks, rng, scales)
+    breaks <- res$breaks
+    scales <- res$scales
 
-    #xlab <- x$label$x
-    #ylab <- x$label$y
-    #x <- x + xlab(NULL) + ylab(NULL)
     totallabs <- extract_totallabs(plot=x)
     if (length(totallabs) > 0){
         x$labels[names(totallabs)] <- NULL
@@ -33,7 +32,7 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
     coord_fun <- check_coord_flip(plot=x, axis=axis) 
     newxlab <- switch(coord_fun, coord_flip=totallabs$y, coord_cartesian=totallabs$x)
     newylab <- switch(coord_fun, coord_flip=totallabs$x, coord_cartesian=totallabs$y)
-    relrange <- compute_relative_range(breaks=breaks, scales=scales, rng=rng, coord_fun=coord_fun, axis=axis)
+    relrange <- compute_relative_range(breaks=breaks, scales=scales, rng=rng)
     if(axis == 'x') {
         p1 <- x + do.call(coord_fun, list(xlim = c(breaks[[1]][1], breaks[[1]][2]))) + subplottheme1
         pp1 <- lapply(breaks[-c(1, nbreaks)], function(i) 
@@ -46,9 +45,9 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
         #            coord_cartesian=plot_grid(plotlist=c(list(p1), pp1, list(pp2)), align="h", nrow=1)
         #            )
         g <- switch(coord_fun,
-                    coord_flip = plot_list(gglist=c(list(pp2), pp1, list(p1)), 
+                    coord_flip = plot_list(gglist=c(list(pp2), rev(pp1), list(p1)), 
                                            ncol=1,
-                                           heights=c(relrange[-1], relrange[1]),
+                                           heights=c(rev(relrange[-1]), relrange[1]),
                                            guides = 'collect'),
                     coord_cartesian = plot_list(gglist=c(list(p1), pp1, list(pp2)), 
                                                 nrow=1, 
@@ -68,13 +67,13 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
         #            coord_cartesian = plot_grid(plotlist=c(list(pp2), pp1, list(p1)), align="v", ncol=1)
         #       )
         g <- switch(coord_fun,
-                    coord_flip = plot_list(gglist=c(list(p1), pp1, list(pp2)), 
+                    coord_flip = plot_list(gglist=c(list(p1), rev(pp1), list(pp2)), 
                                            nrow=1, 
                                            widths=relrange,
                                            guides = 'collect'),
                     coord_cartesian = plot_list(gglist=c(list(pp2), pp1, list(p1)), 
                                                 ncol=1, 
-                                                heights=c(relrange[-1], relrange[1]),
+                                                heights=c(rev(relrange[-1]), relrange[1]),
                                                 guides = 'collect')
                )
     }


### PR DESCRIPTION
+ fix multiple ( >=3 ) scale_xx_break bug
+ fix the order of relative width/height of subplot.
+ compatible theme_classic

```
require(ggplot2)
library(ggbreak)
set.seed(2019-01-19)
d <- data.frame(
  x = 1:20,
  y = c(rnorm(5) + 4, rnorm(5) + 20, rnorm(5) + 5, rnorm(5) + 22)
)

p <- ggplot(d, aes(x=y, y=x)) + geom_col(orientation="y") +
     scale_x_reverse() +
     theme_classic()

x <- p +
     scale_x_break(c(7, 12)) +
     scale_x_break(c(17, 19)) +
     scale_x_break(c(13, 15)) +
     coord_flip()
x
```

![test1](https://user-images.githubusercontent.com/17870644/118250440-11889a00-b4d9-11eb-823e-c435aeeab3e7.PNG)
