### PR TITLE
compatible with part legend.position

### DIFF
--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -37,6 +37,7 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
     newxlab <- switch(coord_fun, coord_flip=totallabs$y, coord_cartesian=totallabs$x)
     newylab <- switch(coord_fun, coord_flip=totallabs$x, coord_cartesian=totallabs$y)
     relrange <- compute_relative_range(breaks=breaks, scales=scales, rng=rng)
+    legendpos <- check_legend_position(plot=x)
     if (!rng$flagrev %in% c("identity","reverse")){
         breaks <- lapply(breaks, function(i)rng$inversefun(i))
     }
@@ -87,11 +88,11 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
                     coord_flip = plot_list(gglist=c(list(pp2), rev(pp1), list(p1)), 
                                            ncol=1,
                                            heights=c(rev(relrange[-1]), relrange[1]),
-                                           guides = 'collect'),
+                                           guides = 'collect') & legendpos,
                     coord_cartesian = plot_list(gglist=c(list(p1), pp1, list(pp2)), 
                                                 nrow=1, 
                                                 widths=relrange,
-                                                guides = 'collect')
+                                                guides = 'collect') & legendpos
                     )
     } else {
         breaks <- rev(breaks)
@@ -138,11 +139,11 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
                     coord_flip = plot_list(gglist=c(list(p1), rev(pp1), list(pp2)), 
                                            nrow=1, 
                                            widths=relrange,
-                                           guides = 'collect'),
+                                           guides = 'collect') & legendpos,
                     coord_cartesian = plot_list(gglist=c(list(pp2), pp1, list(p1)), 
                                                 ncol=1, 
                                                 heights=c(rev(relrange[-1]), relrange[1]),
-                                                guides = 'collect')
+                                                guides = 'collect') & legendpos
                )
     }
 
@@ -176,8 +177,9 @@ grid.draw.ggwrap <- function(x, recording=TRUE){
     if (!rngrev$flagrev %in% c("identity", "reverse")){
         breaks <- rngrev$inversefun(breaks)
     }
+    legendpos <- check_legend_position(plot=x)
     gg <- lapply(seq_len(length(breaks)-1), function(i) x + coord_cartesian(xlim=c(breaks[i], breaks[i+1])))
-    pg <- plot_list(gg, ncol=1, guides="collect")
+    pg <- plot_list(gg, ncol=1, guides="collect") & legendpos
     g <- set_label(as.ggplot(pg), totallabs=totallabs, p2=x)
     if (recording){
         print(g)
@@ -209,6 +211,7 @@ grid.draw.ggcut <- function(x, recording=TRUE){
     coord_fun <- check_coord_flip(plot=x)
     newxlab <- switch(coord_fun, coord_flip=totallabs$y, coord_cartesian=totallabs$x)
     newylab <- switch(coord_fun, coord_flip=totallabs$x, coord_cartesian=totallabs$y)
+    legendpos <- check_legend_position(plot=x)
     if (!rngrev$flagrev %in% c("identity", "reverse")){
         breaks <- rngrev$inversefun(breaks)
     }
@@ -223,11 +226,11 @@ grid.draw.ggcut <- function(x, recording=TRUE){
                     coord_flip = plot_list(gglist=c(list(pp2), rev(pp1), list(p1)),
                                            ncol=1,
                                            heights=relrange,#c(rev(relrange[-1]), relrange[1]),
-                                           guides = 'collect'),
+                                           guides = 'collect') & legendpos, 
                     coord_cartesian = plot_list(gglist=c(list(p1), pp1, list(pp2)),
                                                 nrow=1,
                                                 widths=relrange,
-                                                guides = 'collect')
+                                                guides = 'collect') & legendpos
                     )
     } else {
         breaks <- rev(breaks)
@@ -241,11 +244,11 @@ grid.draw.ggcut <- function(x, recording=TRUE){
                     coord_flip = plot_list(gglist=c(list(p1), rev(pp1), list(pp2)),
                                            nrow=1,
                                            widths=relrange,
-                                           guides = 'collect'),
+                                           guides = 'collect') & legendpos,
                     coord_cartesian = plot_list(gglist=c(list(pp2), pp1, list(p1)),
                                                 ncol=1,
                                                 heights=relrange,#c(rev(relrange[-1]), relrange[1]),
-                                                guides = 'collect')
+                                                guides = 'collect') & legendpos
                )
     }
     totallabs$x <- NULL

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -10,6 +10,15 @@ ggrange2 <- function (plot, var) {
     list(axis_range=axis_range, flagrev=flagrev, transfun=transfun, inversefun=inversefun)
 }
 
+check_legend_position <- function(plot){
+    if (!is.null(plot$theme$legend.position)){
+        tm <- theme(legend.position=plot$theme$legend.position)
+    }else{
+        tm <- theme()
+    }
+    return (tm)
+}
+
 #' @importFrom ggplot2 labs
 set_label <- function(p, totallabs, p2 = NULL) {
     p <- p + 

--- a/vignettes/ggbreak.Rmd
+++ b/vignettes/ggbreak.Rmd
@@ -149,7 +149,7 @@ print(pg)
 pg + labs(title="test title", subtitle="test subtitle", tag="A tag", caption="A caption") +
      theme_bw() +
      theme(
-           legend.position = c(0.8, 0.8),
+           legend.position = "bottom",
            strip.placement = "outside",
            axis.title.x=element_text(size=10),
            plot.title = element_text(size = 22),


### PR DESCRIPTION
compatible with part `legend.position`, but manual position (c(0.8, 0.7)) is not supported.

```
require(ggplot2)
library(ggbreak)

set.seed(2019-01-19)
d <- data.frame(
  x = 1:20,
  y = c(rnorm(5) + 4, rnorm(5) + 20, rnorm(5) + 5, rnorm(5) + 22),
  group = c(rep("A", 10), rep("B", 10)),
  face=c(rep("C", 5), rep("D", 5), rep("E", 5), rep("F", 5))
)


p <- ggplot(d, aes(x=x, y=y)) +
     geom_col(aes(fill=group),orientation="x")

x <- p + scale_y_break(c(7, 17)) + theme(legend.position="bottom")
x
```
![test_bar](https://user-images.githubusercontent.com/17870644/120097330-704d4500-c162-11eb-809a-1d491c33f5df.png)
