### PR TITLE
fix text and title of theme

### DIFF
--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -148,9 +148,9 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
                )
     }
 
-    totallabs$x <- NULL
-    totallabs$y <- NULL
-    g <- ggplotify::as.ggplot(g) + xlab(newxlab) + ylab(newylab)
+    totallabs$x <- newxlab #NULL
+    totallabs$y <- newylab #NULL
+    g <- ggplotify::as.ggplot(g) #+ xlab(newxlab) + ylab(newylab)
     g <- set_label(g, totallabs = totallabs, p2 = x)
     if (recording){
         print(g)
@@ -252,9 +252,9 @@ grid.draw.ggcut <- function(x, recording=TRUE){
                                                 guides = 'collect') & legendpos
                )
     }
-    totallabs$x <- NULL
-    totallabs$y <- NULL
-    g <- ggplotify::as.ggplot(g) + xlab(newxlab) + ylab(newylab)
+    totallabs$x <- newxlab #NULL
+    totallabs$y <- newylab #NULL
+    g <- ggplotify::as.ggplot(g) #+ xlab(newxlab) + ylab(newylab)
     g <- set_label(g, totallabs = totallabs, p2 = x)
     if (recording){
         print(g)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -22,8 +22,7 @@ check_legend_position <- function(plot){
 #' @importFrom ggplot2 labs
 set_label <- function(p, totallabs, p2 = NULL) {
     p <- p + 
-         do.call(labs, totallabs) #+
-         #theme(axis.title = element_text())
+         do.call(labs, totallabs) 
 
     if (is.null(p2)) {
         has_theme <- FALSE
@@ -32,14 +31,18 @@ set_label <- function(p, totallabs, p2 = NULL) {
     }
 
     if (has_theme) {
-        x <- p2
+        x <- p2 
     } else {
         x <- NULL
     }
     labs_params <- c("text", "title", "axis.title", "axis.title.x","axis.title.y", 
                      "plot.title", "plot.title.position", "plot.subtitle",
                      "plot.caption", "plot.caption.position", "plot.tag", "plot.tag.position")
-    p <- p + theme_fp(x=x, i=labs_params)
+    p <- p + 
+         theme_fp(x=x, i=labs_params) +
+         theme(axis.text = element_blank(),
+               axis.ticks = element_blank()
+               )
     return(p)
 }
 
@@ -182,6 +185,7 @@ get_theme_params = function(x, i) {
 
 theme_fp <- function(x, i) {
     params <- get_theme_params(x, i)
+    params <- c(params, list(complete = TRUE))
     do.call(theme, params)
 }
 


### PR DESCRIPTION
fix the text and title of `theme`.

The related issue #24 

```
library(magrittr)
library(ggplot2)
library(ggbreak)
data("cars")

cars %>% ggplot(aes(x = speed)) +
  geom_bar() +
  scale_y_break(c(2,3)) +
  theme(text = element_text(family = "Comic Sans MS", face="bold"))
```
![xx](https://user-images.githubusercontent.com/17870644/132622027-f5c3ac5a-06db-40c2-acb1-eea7b3a026e7.PNG)
