### PR TITLE
fix x y labels and introduce scale_xy_expand options

### DIFF
--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -47,14 +47,15 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
     }else{
         scaleind <- NULL
     }
+    expand <- getOption(x="scale_xy_expand", default = FALSE)
     if(axis == 'x') {
-        p1 <- x + do.call(coord_fun, list(xlim = c(breaks[[1]][1], breaks[[1]][2]), expand=FALSE)) + subplottheme1
+        p1 <- x + do.call(coord_fun, list(xlim = c(breaks[[1]][1], breaks[[1]][2]), expand = expand)) + subplottheme1
 
         pp1 <- lapply(breaks[-c(1, nbreaks)], function(i) 
-                            x + do.call(coord_fun, list(xlim=c(i[1], i[2]), expand=FALSE)) + 
+                            x + do.call(coord_fun, list(xlim=c(i[1], i[2]), expand = expand)) + 
                             subplottheme2)
         
-        pp2 <- x + do.call(coord_fun, list(xlim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand=FALSE)) +
+        pp2 <- x + do.call(coord_fun, list(xlim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand= expand)) +
                subplottheme3
 
         if (length(ticklabs) > 1){
@@ -99,13 +100,13 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
         breaks <- rev(breaks)
         ticklabs <- rev(ticklabs)
 
-        p1 <- x + do.call(coord_fun, list(ylim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand=FALSE)) + subplottheme1
+        p1 <- x + do.call(coord_fun, list(ylim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand = expand)) + subplottheme1
 
         pp1 <- lapply(breaks[-c(1, nbreaks)], function(i) 
-                      x + do.call(coord_fun, list(ylim=c(i[1], i[2]), expand=FALSE)) +
+                      x + do.call(coord_fun, list(ylim=c(i[1], i[2]), expand = expand)) +
                             subplottheme2)
 
-        pp2 <- x + do.call(coord_fun, list(ylim = c(breaks[[1]][1], breaks[[1]][2]), expand=FALSE)) +
+        pp2 <- x + do.call(coord_fun, list(ylim = c(breaks[[1]][1], breaks[[1]][2]), expand = expand)) +
                subplottheme3
         
         if (length(ticklabs) > 1){
@@ -148,9 +149,9 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
                )
     }
 
-    totallabs$x <- newxlab #NULL
-    totallabs$y <- newylab #NULL
-    g <- ggplotify::as.ggplot(g) #+ xlab(newxlab) + ylab(newylab)
+    totallabs$x <- NULL
+    totallabs$y <- NULL
+    g <- ggplotify::as.ggplot(g) + xlab(newxlab) + ylab(newylab)
     g <- set_label(g, totallabs = totallabs, p2 = x)
     if (recording){
         print(g)
@@ -179,7 +180,8 @@ grid.draw.ggwrap <- function(x, recording=TRUE){
         breaks <- rngrev$inversefun(breaks)
     }
     legendpos <- check_legend_position(plot=x)
-    gg <- lapply(seq_len(length(breaks)-1), function(i) x + coord_cartesian(xlim=c(breaks[i], breaks[i+1]), expand=FALSE))
+    expand <- getOption(x="scale_xy_expand", default = FALSE)
+    gg <- lapply(seq_len(length(breaks)-1), function(i) x + coord_cartesian(xlim=c(breaks[i], breaks[i+1]), expand = expand))
     pg <- plot_list(gglist=setNames(gg, NULL), ncol=1, guides="collect") & legendpos
     g <- set_label(as.ggplot(pg), totallabs=totallabs, p2=x)
     if (recording){
@@ -216,12 +218,13 @@ grid.draw.ggcut <- function(x, recording=TRUE){
     if (!rngrev$flagrev %in% c("identity", "reverse")){
         breaks <- rngrev$inversefun(breaks)
     }
+    expand <- getOption(x="scale_xy_expand", default = FALSE)
     if(axis == 'x') {
-        p1 <- x + do.call(coord_fun, list(xlim = c(breaks[[1]][1], breaks[[1]][2]), expand=FALSE)) + subplottheme1
+        p1 <- x + do.call(coord_fun, list(xlim = c(breaks[[1]][1], breaks[[1]][2]), expand = expand)) + subplottheme1
         pp1 <- lapply(breaks[-c(1, nbreaks)], function(i)
-                            x + do.call(coord_fun, list(xlim=c(i[1], i[2]), expand=FALSE)) +
+                            x + do.call(coord_fun, list(xlim=c(i[1], i[2]), expand = expand)) +
                             subplottheme2)
-        pp2 <- x + do.call(coord_fun, list(xlim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand=FALSE)) +
+        pp2 <- x + do.call(coord_fun, list(xlim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand = expand)) +
                subplottheme3
         g <- switch(coord_fun,
                     coord_flip = plot_list(gglist=setNames(c(list(pp2), rev(pp1), list(p1)), NULL),
@@ -235,11 +238,11 @@ grid.draw.ggcut <- function(x, recording=TRUE){
                     )
     } else {
         breaks <- rev(breaks)
-        p1 <- x + do.call(coord_fun, list(ylim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand=FALSE)) + subplottheme1
+        p1 <- x + do.call(coord_fun, list(ylim = c(breaks[[nbreaks]][1], breaks[[nbreaks]][2]), expand = expand)) + subplottheme1
         pp1 <- lapply(breaks[-c(1, nbreaks)], function(i)
-                      x + do.call(coord_fun, list(ylim=c(i[1], i[2]), expand=FALSE)) +
+                      x + do.call(coord_fun, list(ylim=c(i[1], i[2]), expand = expand)) +
                             subplottheme2)
-        pp2 <- x + do.call(coord_fun, list(ylim = c(breaks[[1]][1], breaks[[1]][2]), expand=FALSE)) +
+        pp2 <- x + do.call(coord_fun, list(ylim = c(breaks[[1]][1], breaks[[1]][2]), expand = expand)) +
                subplottheme3
         g <- switch(coord_fun,
                     coord_flip = plot_list(gglist=setNames(c(list(p1), rev(pp1), list(pp2)), NULL),
@@ -252,9 +255,9 @@ grid.draw.ggcut <- function(x, recording=TRUE){
                                                 guides = 'collect') & legendpos
                )
     }
-    totallabs$x <- newxlab #NULL
-    totallabs$y <- newylab #NULL
-    g <- ggplotify::as.ggplot(g) #+ xlab(newxlab) + ylab(newylab)
+    totallabs$x <- NULL
+    totallabs$y <- NULL
+    g <- ggplotify::as.ggplot(g) + xlab(newxlab) + ylab(newylab)
     g <- set_label(g, totallabs = totallabs, p2 = x)
     if (recording){
         print(g)


### PR DESCRIPTION
+ fix the issues of x and y labels if they are NULL.

+ introduce `scale_xy_expand` to control how to set the `expand` of `coord`.
    default is `FALSE`. 
   But users can set it to `TRUE` via `options("scale_xy_expand"=TRUE)` 

```
> library(ggbreak)
> example(scale_y_break)

scl_y_> require(ggplot2 )
Loading required package: ggplot2

scl_y_> set.seed(2019-01-19)

scl_y_> d <- data.frame(
scl_y_    x = 1:20,
scl_y_    y = c(rnorm(5) + 4, rnorm(5) + 20, rnorm(5) + 5, rnorm(5) + 22)
scl_y_  )

scl_y_> p <- ggplot(d, aes(x, y)) + geom_col()

scl_y_> x <- p+scale_y_break(c(7, 17 ) )

scl_y_> print(x)
```

![x1](https://user-images.githubusercontent.com/17870644/133233308-037eb32a-c145-4a43-82e8-746dc7ef9f2b.PNG)

```
options(scale_xy_expand=TRUE)
x
```
![x2](https://user-images.githubusercontent.com/17870644/133233407-b3b4097a-0cc9-433e-a3db-2d780ee6d391.PNG)
