### PR TITLE
xy intercept and limits

### DIFF
--- a/R/grid-draw-utilities.R
+++ b/R/grid-draw-utilities.R
@@ -104,6 +104,12 @@ is_numeric <- function(x) {
     !anyNA(suppressWarnings(as.numeric(x)))
 }
 
-extract_wrap_breaks <- function(){
-
+check_xy_intercept <- function(plot){
+    if ("yintercept" %in% plot$labels){
+        plot$labels$yintercept <- NULL
+    }
+    if ("xintercept" %in% plot$labels){
+        plot$labels$xintercept <- NULL
+    }
+    return (plot)
 }

--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -14,6 +14,7 @@
 ##' @export
 grid.draw.ggbreak <- function(x, recording = TRUE) {
     class(x) <- class(x)[class(x) != "ggbreak"]
+    x <- check_xy_intercept(plot=x)
     axis_break <- attr(x, 'axis_break')
     axis_breaks <- extract_axis_break(object=axis_break)
     axis <- axis_breaks$axis
@@ -156,7 +157,6 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
     if (recording){
         print(g)
     }
-    
     invisible(g)
 }
 
@@ -164,6 +164,7 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
 ##' @export
 grid.draw.ggwrap <- function(x, recording=TRUE){
     class(x) <- class(x)[class(x) != "ggwrap"]
+    x <- check_xy_intercept(plot=x)
     axis_wrap <- attr(x, "axis_wrap")
     totallabs <- extract_totallabs(plot=x)
     if (length(totallabs) > 0){
@@ -196,6 +197,7 @@ grid.draw.ggwrap <- function(x, recording=TRUE){
 #' @export
 grid.draw.ggcut <- function(x, recording=TRUE){
     class(x) <- class(x)[class(x) != "ggcut"]
+    x <- check_xy_intercept(plot=x)
     axis_cut <- attr(x, "axis_cut")
     axis <- axis_cut$axis
     totallabs <- extract_totallabs(plot=x)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3,7 +3,12 @@
 ggrange2 <- function (plot, var) {
     var <- paste0("panel_scales_", var)
     gb <- ggplot_build(plot)
-    axis_range <- gb$layout[[var]][[1]]$range$range
+    limits <- gb$layout[[var]][[1]]$limits
+    if (!is.null(limits)){
+        axis_range <- limits
+    }else{
+        axis_range <- gb$layout[[var]][[1]]$range$range
+    }
     flagrev <- gb$layout[[var]][[1]]$trans$name
     transfun <- gb$layout[[var]][[1]]$trans$transform
     inversefun <- gb$layout[[var]][[1]]$trans$inverse


### PR DESCRIPTION
+ fix the label issue of x or y intercept
+ compatible with x or y limits

## intercept labels

```
library(ggplot2)
library(ggbreak)
data <- data.frame(x = c(1:10),
                   y = c(5:13, 100))
p <- ggplot(data, aes(x = x, y = y)) +
    geom_point() +
    geom_hline(aes(yintercept = 3))
p + scale_y_break(c(14, 90), scale=0.2)
```
![xx1](https://user-images.githubusercontent.com/17870644/134646202-651a600f-ccba-4cd0-8cca-0e4506884d48.PNG)

## limits
```
p + scale_y_break(c(14, 90), scale=0.2) + ylim(c(0, 110))
```
![xx2](https://user-images.githubusercontent.com/17870644/134646215-32f03373-0c3c-4101-a22b-f5780f3af6c7.PNG)
