### PR TITLE
scale_wrap supports non-numeric axis

### DIFF
--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -213,13 +213,17 @@ grid.draw.ggwrap <- function(x, recording=TRUE){
     expand <- axis_wrap$expand
     rngrev <- ggrange2(plot=x, 'x')
     rng <- rngrev$axis_range
-    if (rngrev$flagrev == "reverse"){
+    if (is.null(rngrev$flagrev)){
+        rng <- c(.5, length(rng))
+    }else if (rngrev$flagrev == "reverse"){
         rng <- rev(-1 * (rng))
     }
     breaks <- seq(rng[1], rng[2], length.out=nstep + 1)
-    if (!rngrev$flagrev %in% c("identity", "reverse")){
+    if (is.null(rngrev$flagrev)) {
+        breaks <- round(breaks, 0) + .5
+    } else if (!rngrev$flagrev %in% c("identity", "reverse")){
         breaks <- rngrev$inversefun(breaks)
-    }
+    } 
     x <- add_expand(plot = x, expand = expand, axis = "x")
     legendpos <- check_legend_position(plot=x)
     gg <- lapply(seq_len(length(breaks)-1), function(i) x + coord_cartesian(xlim=c(breaks[i], breaks[i+1])))

--- a/R/method-grid-draw.R
+++ b/R/method-grid-draw.R
@@ -54,10 +54,14 @@ grid.draw.ggbreak <- function(x, recording = TRUE) {
         if (!inherits(x$scales$scales[[scaleind]]$name, "waiver")){
             axis.title <- x$scales$scales[[scaleind]]$name
             x <- remove_axis_title(x, axis, coord_fun)
+        }else{
+            axis.title <- NULL
         }
         if (!inherits(x$scales$scales[[scaleind]]$secondary.axis$name, "waiver")){
             axis.sec.title <- x$scales$scales[[scaleind]]$secondary.axis$name
             x <- remove_axis_title(x, axis, coord_fun, second = TRUE)
+        }else{
+            axis.sec.title <- NULL
         }
     }else{
         scale_axis <- switch(axis, x=scale_x_continuous, y=scale_y_continuous)
@@ -223,7 +227,7 @@ grid.draw.ggwrap <- function(x, recording=TRUE){
         breaks <- round(breaks, 0) + .5
     } else if (!rngrev$flagrev %in% c("identity", "reverse")){
         breaks <- rngrev$inversefun(breaks)
-    } 
+    }
     x <- add_expand(plot = x, expand = expand, axis = "x")
     legendpos <- check_legend_position(plot=x)
     gg <- lapply(seq_len(length(breaks)-1), function(i) x + coord_cartesian(xlim=c(breaks[i], breaks[i+1])))


### PR DESCRIPTION
scale_wrap supports non-numeric axis

related issues are #18 and #38


```
library(ggplot2)
library(ggbreak)

p <- ggplot(mpg, aes(class, hwy))
p <- p + geom_boxplot()
p1 <- p +
      scale_wrap(n = 2)
p1
```
![xx](https://user-images.githubusercontent.com/17870644/149655140-b0521ae2-2dd3-411c-89e5-445b42f893cc.PNG)
