### PR TITLE
fix the issues of confusing x or y labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Suggests:
   knitr,
   prettydoc,
   rmarkdown,
-  patchwork
+  patchwork,
+  pillar
 VignetteBuilder: knitr
 License: Artistic-2.0
 Encoding: UTF-8

--- a/R/grid-draw-utilities.R
+++ b/R/grid-draw-utilities.R
@@ -145,12 +145,10 @@ is_numeric <- function(x) {
 }
 
 check_xy_intercept <- function(plot){
-    if ("yintercept" %in% plot$labels){
-        plot$labels$yintercept <- NULL
-    }
-    if ("xintercept" %in% plot$labels){
-        plot$labels$xintercept <- NULL
-    }
+    confuse_xy_labs <- c("xend", "xmax", "xmin", "xintercept", 
+                         "yend", "ymax", "ymin", "yintercept")
+    index <- which(names(plot$labels) %in% confuse_xy_labs)
+    plot$labels[index] <- NULL
     return (plot)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,19 +1,21 @@
 ##' @importFrom utils packageDescription
 .onAttach <- function(libname, pkgname) {
     pkgVersion <- packageDescription(pkgname, fields="Version")
-    msg <- paste0(pkgname, " v", pkgVersion, "\n\n")
+    msg <- paste0(pkgname, " v", pkgVersion,"\n\n")
 
-    citation <- paste0("If you use ", pkgname,
-                       " in published research, please cite the following paper:\n\n",
-                       ggbreak_citation(), "\n")
+    citation <- paste0(paste0("If you use ", 
+                              pkgname, 
+                              " in published research, please cite the following paper:\n\n"
+                              ),
+                       ggbreak_citation(), collapse = "\n")
 
-    packageStartupMessage(paste0(msg, citation))
+    packageStartupMessage(paste0(strwrap(pillar::style_subtle(paste0(msg, citation))), collapse="\n"))
 }
 
 
 ggbreak_citation <- function() {
-    paste("S Xu, M Chen, T Feng, L Zhan, L Zhou, G Yu.",
-           "Use ggbreak to effectively utilize plotting space to deal with large datasets and outliers.",
+    paste0("S Xu, M Chen, T Feng, L Zhan, L Zhou, G Yu. ",
+           "Use ggbreak to effectively utilize plotting space to deal with large datasets and outliers. ",
            "Frontiers in Genetics. 2021, 12:774846. doi: 10.3389/fgene.2021.774846\n"
            )
 }


### PR DESCRIPTION
If the `xend`, `yend`, `xmax`, `xmin` and `ymax` etc are used in `aes`, they might be displayed after `ggbreak`.

a related issue is #28 .
