### PR TITLE
S3 method consistency

### DIFF
--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -2,7 +2,7 @@
 ##' @importFrom rlang abort
 ##' @method ggplot_add ggbreak_params
 ##' @export
-ggplot_add.ggbreak_params <- function(object, plot, object_name) {
+ggplot_add.ggbreak_params <- function(object, plot, ...) {
     if (inherits(plot, "ggbreak")){
         origin_axis_break <- attr(plot, 'axis_break')
         origin_axis <- ifelse(inherits(origin_axis_break, "ggbreak_params"), 
@@ -24,7 +24,7 @@ ggplot_add.ggbreak_params <- function(object, plot, object_name) {
 
 ##' @method ggplot_add wrap_params
 ##' @export
-ggplot_add.wrap_params <- function(object, plot, object_name){
+ggplot_add.wrap_params <- function(object, plot, ...){
     attr(plot, "axis_wrap") <- object
     class(plot) <- c("ggwrap", class(plot))
     return(plot)
@@ -33,7 +33,7 @@ ggplot_add.wrap_params <- function(object, plot, object_name){
 
 ##' @method ggplot_add ggcut_params
 ##' @export
-ggplot_add.ggcut_params <- function(object, plot, object_name){
+ggplot_add.ggcut_params <- function(object, plot, ...){
     attr(plot, "axis_cut") <- object
     class(plot) <- c("ggcut", class(plot))
     return (plot)
@@ -42,15 +42,15 @@ ggplot_add.ggcut_params <- function(object, plot, object_name){
 ##' @method ggplot_add ggbreak
 ##' @importFrom ggfun is.ggbreak
 ##' @export
-ggplot_add.ggbreak <- function(object, plot, object_name) {
+ggplot_add.ggbreak <- function(object, plot, ...) {
     if (is.ggbreak(plot)) {
         ggplot_add(ggbreak2ggplot(object),
                    ggbreak2ggplot(plot),
-                   object_name)
+                   ...)
     } else{
         ggplot_add(as.ggplot(grid.draw(object, recording=FALSE)),
                    as.ggplot(plot),
-               object_name)
+                   ...)
     }
 }
 
@@ -66,9 +66,9 @@ ggplot_add.ggcut <- ggplot_add.ggbreak
 ##' @method ggplot_add gg
 ##' @importFrom ggfun ggbreak2ggplot
 ##' @export
-ggplot_add.gg <- function(object, plot, object_name){
+ggplot_add.gg <- function(object, plot, ...){
     if (is.ggbreak(plot)){
-        ggplot_add(as.ggplot(object), ggbreak2ggplot(plot), object_name)
+        ggplot_add(as.ggplot(object), ggbreak2ggplot(plot), ...)
     } else{
         NextMethod()
     }


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found two issues during a reverse dependency check.
One of the issues is the consistency of S3 methods, which this PR adresses.
The second issue is that the vignette couldn't render, which is not adressed in this PR. I lack the understanding of how ggbreak works to fix the second issue in this PR.


You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun

